### PR TITLE
Update email sender name and simplify HTML nullish check

### DIFF
--- a/src/utils/Email/index.ts
+++ b/src/utils/Email/index.ts
@@ -92,10 +92,10 @@ export default class EmailService {
                 // Use Promise.all to wait for all emails to send
                 await Promise.all((options.postmarkInfo ?? []).map(async (recipient) => {
                     const mailOptions = {
-                        from: `Base Accounts<${EMAIL_SERVICE === 'zoho' ? ZOHO_USERNAME : EMAIL_HOST_ADDRESS}>`,
+                        from: `Busy2Shop Accounts<${EMAIL_SERVICE === 'zoho' ? ZOHO_USERNAME : EMAIL_HOST_ADDRESS}>`,
                         to: recipient.recipientEmail,
                         subject: options.subject,
-                        html: options.html ? options.html : undefined,
+                        html: options.html ?? undefined,
                         attachments: options.attachments,
                     };
 


### PR DESCRIPTION
Changed the sender name in email configurations from "Base Accounts" to "Busy2Shop Accounts" to reflect branding. Simplified the nullish check for the HTML property using the nullish coalescing operator.
This pull request includes a small update to the `EmailService` class in `src/utils/Email/index.ts`. The changes update the sender's name in the `from` field and simplify the handling of the `html` property using the nullish coalescing operator.

* Updated the sender's name in the `from` field from "Base Accounts" to "Busy2Shop Accounts" for email communications.
* Replaced the ternary operator with the nullish coalescing operator (`??`) for the `html` property to simplify the code.